### PR TITLE
Add job description for product security engineer

### DIFF
--- a/src/content/docs/eng-other/product-security-engineer.md
+++ b/src/content/docs/eng-other/product-security-engineer.md
@@ -1,0 +1,49 @@
+---
+title: Product Security Engineer
+description: An AI generated job description for a Product Security Engineer
+---
+
+**Title**: Product Security Engineer
+
+**Location**: [Your City, Your State/Country]
+
+### About Us
+
+[Company Name] is a leading [industry/type] company, dedicated to [brief description of company mission or products/services]. We are committed to building secure, reliable products that protect our customers' data and maintain their trust. Security is at the core of everything we do, and we're looking for passionate individuals who share our commitment to protecting users and their information.
+
+### Position Overview
+
+We are seeking an experienced Product Security Engineer to join our security team. As a Product Security Engineer, you will be responsible for integrating security into every aspect of our product development lifecycle. You will work closely with engineering, product, and design teams to identify security risks, implement security controls, and ensure our products are built with security by design principles from the ground up.
+
+### Key Responsibilities
+
+- Conduct security reviews and threat modeling for new features and products throughout the development lifecycle.
+- Collaborate with engineering teams to integrate security controls and best practices into the product development process.
+- Perform security assessments, code reviews, and penetration testing to identify and remediate vulnerabilities.
+- Design and implement security frameworks, tools, and automation to scale security practices across development teams.
+- Develop and maintain security standards, guidelines, and documentation for product development.
+- Investigate and respond to security incidents related to product vulnerabilities and security issues.
+- Stay current with emerging security threats, vulnerabilities, and industry best practices to proactively address potential risks.
+- Work with external security researchers and manage responsible disclosure processes for security vulnerabilities.
+- Provide security training and guidance to development teams to promote security awareness and best practices.
+- Collaborate with compliance and legal teams to ensure products meet regulatory and industry security requirements.
+
+### Qualifications
+
+- Bachelor's or Master's degree in Computer Science, Cybersecurity, Engineering, or a related field.
+- Minimum of 4-6 years of experience in product security, application security, or related cybersecurity roles.
+- Strong understanding of secure coding practices, common vulnerabilities (OWASP Top 10), and security testing methodologies.
+- Experience with security tools and technologies (e.g., SAST, DAST, dependency scanning, threat modeling tools).
+- Proficiency in multiple programming languages (e.g., Python, Java, JavaScript, Go) and ability to review code for security issues.
+- Knowledge of cloud security principles and experience with cloud platforms (AWS, Google Cloud, Azure).
+- Familiarity with DevSecOps practices and experience integrating security into CI/CD pipelines.
+- Strong analytical and problem-solving skills with the ability to think like an attacker and defender.
+- Excellent communication skills and ability to work collaboratively with cross-functional teams.
+- Security certifications (e.g., CISSP, OSCP, CEH, CSSLP) are a plus.
+
+### Why Join Us
+
+- Opportunity to shape the security posture of products used by millions of users worldwide.
+- Collaborative and innovative work environment with a strong focus on security culture.
+- Competitive salary and comprehensive benefits package.
+- Opportunities for professional development, security conferences, and continuous learning.


### PR DESCRIPTION
Add Product Security Engineer job description under `eng-other` following existing format and style.